### PR TITLE
feat: add argocli rock definition

### DIFF
--- a/argocli/rockcraft.yaml
+++ b/argocli/rockcraft.yaml
@@ -77,13 +77,14 @@ parts:
       - etc/ssh/ssh_known_hosts
       - etc/ssh/nsswitch.conf
 
-  # commented due to issue https://github.com/canonical/argo-workflows-rocks/issues/5
-  # non-root-user:
-  #   plugin: nil
-  #   after: [copy]
-  #   overlay-script: |
-  #     # Create a user in the $CRAFT_OVERLAY chroot
-  #     groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
-  #     useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
-  #   override-prime: |
-  #     craftctl default
+  non-root-user:
+    plugin: nil
+    after: [copy]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      mkdir $CRAFT_OVERLAY/etc
+      chmod 755 $CRAFT_OVERLAY/etc
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+    override-prime: |
+      craftctl default

--- a/argocli/rockcraft.yaml
+++ b/argocli/rockcraft.yaml
@@ -77,6 +77,7 @@ parts:
       - etc/ssh/ssh_known_hosts
       - etc/ssh/nsswitch.conf
 
+  # commented due to issue https://github.com/canonical/argo-workflows-rocks/issues/5
   # non-root-user:
   #   plugin: nil
   #   after: [copy]

--- a/argocli/rockcraft.yaml
+++ b/argocli/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: argo-cli
 summary: "Argo Server rock"
 description: "Container-Native Workflow Engine for Kubernetes"
-version: "v3.3.8_1"
+version: "v3.3.8_22.04_1" # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
 license: Apache-2.0
 base: bare
 build-base: ubuntu:22.04

--- a/argocli/rockcraft.yaml
+++ b/argocli/rockcraft.yaml
@@ -1,0 +1,88 @@
+name: argo-cli
+summary: "Argo Server rock"
+description: "Container-Native Workflow Engine for Kubernetes"
+version: "v3.3.8_1"
+license: Apache-2.0
+base: bare
+build-base: ubuntu:22.04
+platforms:
+  amd64:
+services:
+  argocli:
+    override: replace
+    summary: "argo-cli service"
+    command: argo
+    startup: enabled
+    user: ubuntu
+
+parts:
+
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+  
+  argo-ui:
+    plugin: npm
+    source: https://github.com/argoproj/argo-workflows
+    source-type: git
+    source-tag: v3.3.8
+    build-snaps:
+      - node/16/stable
+    override-build: |
+      JOBS=max yarn --cwd ui install --network-timeout 1000000
+      NODE_OPTIONS="--max-old-space-size=2048" JOBS=max yarn --cwd ui build
+      cp -r ui/dist/app $CRAFT_STAGE
+
+  argocli-build:
+    after: [argo-ui]
+    plugin: make
+    source: https://github.com/argoproj/argo-workflows
+    source-type: git
+    source-tag: v3.3.8
+    build-snaps:
+      - go/1.17/stable
+    build-packages:
+      - git
+      - ca-certificates
+      - wget
+      - curl
+      - gcc
+      - mailcap
+    override-build: |
+      # argocli-build stage https://github.com/argoproj/argo-workflows/blob/v3.3.8/Dockerfile#L105
+      mkdir -p ${CRAFT_PART_INSTALL}/ui/dist
+      cp -r $CRAFT_STAGE/app ${CRAFT_PART_INSTALL}/ui/dist/
+      touch ${CRAFT_PART_INSTALL}/ui/dist/node_modules.marker
+      touch ${CRAFT_PART_INSTALL}/ui/dist/app/index.html
+      cat .dockerignore >> .gitignore
+      git status --porcelain | cut -c4- | xargs git update-index --skip-worktree
+      make dist/argo
+      install -D -m755 /etc/ssl/certs/ca-certificates.crt ${CRAFT_PART_INSTALL}/etc/ssl/certs/ca-certificates.crt
+      install -D -m755 ./dist/argo ${CRAFT_PART_INSTALL}/bin/argo
+
+
+  copy:
+    after: [argocli-build]
+    plugin: dump
+    source: https://github.com/argoproj/argo-workflows
+    source-type: git
+    source-subdir: hack
+    source-tag: v3.3.8
+    organize:
+      ssh_known_hosts: etc/ssh/ssh_known_hosts
+      nsswitch.conf: etc/ssh/nsswitch.conf
+    prime:
+      - etc/ssh/ssh_known_hosts
+      - etc/ssh/nsswitch.conf
+
+  # non-root-user:
+  #   plugin: nil
+  #   after: [copy]
+  #   overlay-script: |
+  #     # Create a user in the $CRAFT_OVERLAY chroot
+  #     groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+  #     useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+  #   override-prime: |
+  #     craftctl default


### PR DESCRIPTION
Create argo cli rock based on the docker file: https://github.com/argoproj/argo-workflows/blob/v3.3.8/Dockerfile

## Testing
- pack the rock with `rockcraft clean && rockcraft pack --verbosity=trace`
- import the rock into docker, run: `sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:argo-cli_v3.3.8_1_amd64.rock docker-daemon:argo-cli_v3.3.8_1_amd64.rock:rock`
- run the argo command from the rock: `sudo docker run argo-cli_v3.3.8_1_amd64.rock:rock exec argo`
output:
```
2023-05-18T07:40:04.969Z [pebble] Started daemon.
2023-05-18T07:40:04.970Z [pebble] Cannot look up user 0: open /etc/passwd: no such file or directory
2023-05-18T07:40:04.981Z [pebble] POST /v1/exec 11.120092ms 202
2023-05-18T07:40:04.987Z [pebble] GET /v1/tasks/1/websocket/control 5.428986ms 200
2023-05-18T07:40:04.988Z [pebble] GET /v1/tasks/1/websocket/stdio 85.92µs 200
2023-05-18T07:40:04.988Z [pebble] GET /v1/tasks/1/websocket/stderr 70.666µs 200

You can use the CLI in the following modes:

# Kubernetes API Mode (default)

Requests are sent directly to the Kubernetes API. No Argo Server is needed. Large workflows and the workflow archive are not supported.

Use when you have direct access to the Kubernetes API, and don't need large workflow or workflow archive support.

If you're using instance ID (which is very unlikely), you'll need to set it:

        ARGO_INSTANCEID=your-instanceid

# Argo Server GRPC Mode 

Requests are sent to the Argo Server API via GRPC (using HTTP/2). Large workflows and the workflow archive are supported. Network load-balancers that do not support HTTP/2 are not supported. 

Use if you do not have access to the Kubernetes API (e.g. you're in another cluster), and you're running the Argo Server using a network load-balancer that support HTTP/2.

To enable, set ARGO_SERVER:

        ARGO_SERVER=localhost:2746 ;# The format is "host:port" - do not prefix with "http" or "https"

If you're have transport-layer security (TLS) enabled (i.e. you are running "argo server --secure" and therefore has HTTPS):

        ARGO_SECURE=true

If your server is running with self-signed certificates. Do not use in production:

        ARGO_INSECURE_SKIP_VERIFY=true

By default, the CLI uses your KUBECONFIG to determine default for ARGO_TOKEN and ARGO_NAMESPACE. You probably error with "no configuration has been provided". To prevent it:

        KUBECONFIG=/dev/null

You will then need to set:
 
        ARGO_NAMESPACE=argo 

And:

        ARGO_TOKEN='Bearer ******' ;# Should always start with "Bearer " or "Basic ". 

# Argo Server HTTP1 Mode

As per GRPC mode, but uses HTTP. Can be used with ALB that does not support HTTP/2. The command "argo logs --since-time=2020...." will not work (due to time-type).

Use this when your network load-balancer does not support HTTP/2.

Use the same configuration as GRPC mode, but also set:

        ARGO_HTTP1=true

If your server is behind an ingress with a path (you'll be running "argo server --basehref /...) or "BASE_HREF=/... argo server"):

        ARGO_BASE_HREF=/argo

Usage:
  argo [flags]
  argo [command]

Available Commands:
  archive          manage the workflow archive
  auth             manage authentication settings
  cluster-template manipulate cluster workflow templates
  completion       output shell completion code for the specified shell (bash or zsh)
  cron             manage cron workflows
  delete           delete workflows
  executor-plugin  manage executor plugins
  get              display details about a workflow
  help             Help about any command
  lint             validate files or directories of manifests
  list             list workflows
  logs             view logs of a pod or workflow
  node             perform action on a node in a workflow
  resubmit         resubmit one or more workflows
  resume           resume zero or more workflows
  retry            retry zero or more workflows
  server           start the Argo Server
  stop             stop zero or more workflows allowing all exit handlers to run
  submit           submit a workflow
  suspend          suspend zero or more workflow
  template         manipulate workflow templates
  terminate        terminate zero or more workflows immediately
  version          print version information
  wait             waits for workflows to complete
  watch            watch a workflow until it completes

Flags:
      --argo-base-href string          An path to use with HTTP client (e.g. due to BASE_HREF). Defaults to the ARGO_BASE_HREF environment variable.
      --argo-http1                     If true, use the HTTP client. Defaults to the ARGO_HTTP1 environment variable.
  -s, --argo-server host:port          API server host:port. e.g. localhost:2746. Defaults to the ARGO_SERVER environment variable.
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --gloglevel int                  Set the glog logging level
  -H, --header strings                 Sets additional header to all requests made by Argo CLI. (Can be repeated multiple times to add multiple headers, also supports comma separated headers) Used only when either ARGO_HTTP1 or --argo-http1 is set to true.
  -h, --help                           help for argo
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
  -k, --insecure-skip-verify           If true, the Argo Server's certificate will not be checked for validity. This will make your HTTPS connections insecure. Defaults to the ARGO_INSECURE_SKIP_VERIFY environment variable.
      --instanceid string              submit with a specific controller's instance id label. Default to the ARGO_INSTANCEID environment variable.
      --kubeconfig string              Path to a kube config. Only required if out-of-cluster
      --loglevel string                Set the logging level. One of: debug|info|warn|error (default "info")
  -n, --namespace string               If present, the namespace scope for this CLI request
      --password string                Password for basic authentication to the API server
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -e, --secure                         Whether or not the server is using TLS with the Argo Server. Defaults to the ARGO_SECURE environment variable. (default true)
      --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
      --username string                Username for basic authentication to the API server
  -v, --verbose                        Enabled verbose logging, i.e. --loglevel debug

Use "argo [command] --help" for more information about a command.
```