### PR TITLE
chore: bump 3.3.10 -> 3.4.16

### DIFF
--- a/argoexec/rockcraft.yaml
+++ b/argoexec/rockcraft.yaml
@@ -1,14 +1,13 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+# Source: argo-workflows/Dockerfile
 name: argoexec
 summary: An image for Argo Workflows executor.
 description: |
     This image is used as part of the Charmed Kubeflow product. An Argo workflow executor is a process that conforms to a specific interface that allows Argo to perform certain actions like monitoring pod logs, collecting artifacts, managing container lifecycles, etc.
 license: Apache-2.0
 base: ubuntu@22.04
-version: "3.3.10"
+version: "3.4.16"
 run-user: _daemon_
 services:
   argoexec:
@@ -35,26 +34,14 @@ parts:
       - netbase
       - tzdata
 
-  base-snaps:
-    plugin: nil
-    stage-snaps:
-      - docker
-      - kubectl/1.24/stable
-    organize:
-      docker: bin/docker
-      kubectl: bin/kubectl
-    stage:
-      - bin/docker
-      - bin/kubectl
-
   builder:
     plugin: make
     after: [base-deps]
     source: https://github.com/argoproj/argo-workflows
     source-type: git
-    source-tag: v3.3.10
+    source-tag: v3.4.16
     build-snaps:
-      - go/1.17/stable
+      - go/1.20/stable
     build-packages:
       - git
       - ca-certificates
@@ -65,10 +52,8 @@ parts:
       - mailcap
       - procps
       - tar
-      - libcap2-bin
       - libcap2-dev
       - jq
-      - zip
     stage-packages:
       - git
       - libcap2
@@ -76,19 +61,16 @@ parts:
       - tar
       - gzip
     override-build: |
-      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.3.10/Dockerfile#L36
+      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L36
       go mod download
 
       # reset LDFLAGS because Go has different format, i.e. '-L' is undefined in Go
       LDFLAGS=""
 
-      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.3.10/Dockerfile#L82
-      cat .dockerignore >> .gitignore
-      git status --porcelain | cut -c4- | xargs git update-index --skip-worktree
+      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L82
       make dist/argoexec
-      setcap CAP_SYS_PTRACE,CAP_SYS_CHROOT+ei dist/argoexec
 
-      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.3.10/Dockerfile#L132
+      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L132
       install -DT "./dist/argoexec" "$CRAFT_PART_INSTALL/bin/argoexec"
       install -DT "/etc/mime.types" "$CRAFT_PART_INSTALL/etc/mime.types"
 
@@ -98,7 +80,7 @@ parts:
     source: https://github.com/argoproj/argo-workflows
     source-type: git
     source-subdir: hack
-    source-tag: v3.3.10
+    source-tag: v3.4.16
     organize:
       ssh_known_hosts: etc/ssh/ssh_known_hosts
       nsswitch.conf: etc/ssh/nsswitch.conf

--- a/argoexec/rockcraft.yaml
+++ b/argoexec/rockcraft.yaml
@@ -1,6 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-# Source: argo-workflows/Dockerfile
+# Based on: https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile
 name: argoexec
 summary: An image for Argo Workflows executor.
 description: |
@@ -44,16 +44,12 @@ parts:
       - go/1.20/stable
     build-packages:
       - git
+      - make
       - ca-certificates
       - wget
       - curl
       - gcc
-      - make
       - mailcap
-      - procps
-      - tar
-      - libcap2-dev
-      - jq
     stage-packages:
       - git
       - libcap2
@@ -61,16 +57,16 @@ parts:
       - tar
       - gzip
     override-build: |
-      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L36
+      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L21
       go mod download
 
       # reset LDFLAGS because Go has different format, i.e. '-L' is undefined in Go
       LDFLAGS=""
 
-      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L82
+      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L46
       make dist/argoexec
 
-      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L132
+      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L79
       install -DT "./dist/argoexec" "$CRAFT_PART_INSTALL/bin/argoexec"
       install -DT "/etc/mime.types" "$CRAFT_PART_INSTALL/etc/mime.types"
 


### PR DESCRIPTION
Bump the rock to 3.4.16

Fixes #20

I made all changes based on [this diff](https://github.com/argoproj/argo-workflows/compare/v3.3.10...v3.4.16) and the [Dockerfile](https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile) itself.

#### Testing the rock
1. Build the rock `rockcraft pack -v`
2. Copy the rock to a docker local registry `sudo skopeo --insecure-policy copy oci-archive:<argo-rock-name>.rock docker-daemon:argoexec:0.1`
3. Run a container with the image, verify the workload runs correctly. You can exec into the container and run:

```
_daemon_@74a25ea68ce3:~$ argoexec version
argoexec: v3.4.16
  BuildDate: 2024-06-04T11:59:26Z
  GitCommit: 910a9aabce5de6568b54350c181a431f8263605a
  GitTreeState: clean
  GitTag: v3.4.16
  GoVersion: go1.20.14
  Compiler: gc
  Platform: linux/amd64
```