### PR TITLE
 ci: use juju 3.4/stable instead of 3.5/stable 

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -13,6 +13,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable


### PR DESCRIPTION
This PR changes the CI to use Juju version `3.4/stable` instead of `3.5/stable`.