### PR TITLE
cut new branch for CKF 1.8

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -13,6 +13,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -13,6 +13,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.1/stable
+      juju-channel: 3.5/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   on-pull-request:
-    name: Get ROCKs modified and build-scan-test them
+    name: Get rocks modified and build-scan-test them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.1/stable
+      juju-channel: 3.5/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   on-push:
-    name: Get ROCKs modified and build-scan-test-publish them
+    name: Get rocks modified and build-scan-test-publish them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     with:
       microk8s-channel: 1.26-strict/stable
-      juju-channel: 3.5/stable
+      juju-channel: 3.4/stable
       python-version: "3.8"
       rockcraft-channel: latest/stable

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # argo-workflows-rocks
-ROCKs for Argoi Workflows
+rocks for Argoi Workflows


### PR DESCRIPTION
This PR is part of closing [this issue](https://github.com/canonical/bundle-kubeflow/issues/924).

It updates `track/3.3` with the newest commits for CKF 1.8.