### PR TITLE
fix: remove incorrect report-vulnerabilities input from scan_images workflow

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -13,5 +13,4 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:
-      report-vulnerabilities: true
       severity: "HIGH,CRITICAL"


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#1118