### PR TITLE
feat: update `argoexec` rock to 3.4.17

### DIFF
--- a/argoexec/rockcraft.yaml
+++ b/argoexec/rockcraft.yaml
@@ -1,13 +1,13 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-# Based on: https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile
+# Based on: https://github.com/argoproj/argo-workflows/blob/v3.4.17/Dockerfile
 name: argoexec
 summary: An image for Argo Workflows executor.
 description: |
     This image is used as part of the Charmed Kubeflow product. An Argo workflow executor is a process that conforms to a specific interface that allows Argo to perform certain actions like monitoring pod logs, collecting artifacts, managing container lifecycles, etc.
 license: Apache-2.0
 base: ubuntu@22.04
-version: "3.4.16"
+version: "3.4.17"
 run-user: _daemon_
 services:
   argoexec:
@@ -39,9 +39,9 @@ parts:
     after: [base-deps]
     source: https://github.com/argoproj/argo-workflows
     source-type: git
-    source-tag: v3.4.16
+    source-tag: v3.4.17
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-packages:
       - git
       - make
@@ -57,16 +57,16 @@ parts:
       - tar
       - gzip
     override-build: |
-      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L21
+      # builder stage https://github.com/argoproj/argo-workflows/blob/v3.4.17/Dockerfile#L21
       go mod download
 
       # reset LDFLAGS because Go has different format, i.e. '-L' is undefined in Go
       LDFLAGS=""
 
-      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L46
+      # argoexec-build stage https://github.com/argoproj/argo-workflows/blob/v3.4.17/Dockerfile#L46
       make dist/argoexec
 
-      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.4.16/Dockerfile#L79
+      # argoexec stage https://github.com/argoproj/argo-workflows/blob/v3.4.17/Dockerfile#L79
       install -DT "./dist/argoexec" "$CRAFT_PART_INSTALL/bin/argoexec"
       install -DT "/etc/mime.types" "$CRAFT_PART_INSTALL/etc/mime.types"
 
@@ -76,7 +76,7 @@ parts:
     source: https://github.com/argoproj/argo-workflows
     source-type: git
     source-subdir: hack
-    source-tag: v3.4.16
+    source-tag: v3.4.17
     organize:
       ssh_known_hosts: etc/ssh/ssh_known_hosts
       nsswitch.conf: etc/ssh/nsswitch.conf


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6802

Updates: 
- new version of go

Steps to test 
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:argoexec_3.4.17_amd64.rock docker-daemon:misohu/argoexec:3.4.17
docker run <image>
docker exec -ti <container> bash
pebble logs

# Expected output
2025-02-05T09:45:43.382Z [argoexec]   resource    update a resource and wait for resource conditions
2025-02-05T09:45:43.382Z [argoexec]   version     Print version information
2025-02-05T09:45:43.382Z [argoexec]   wait        wait for main container to finish and save artifacts
2025-02-05T09:45:43.382Z [argoexec] 
2025-02-05T09:45:43.382Z [argoexec] Flags:
2025-02-05T09:45:43.382Z [argoexec]       --as string                      Username to impersonate for the operation
2025-02-05T09:45:43.382Z [argoexec]       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
2025-02-05T09:45:43.382Z [argoexec]       --as-uid string                  UID to impersonate for the operation
2025-02-05T09:45:43.382Z [argoexec]       --certificate-authority string   Path to a cert file for the certificate authority
2025-02-05T09:45:43.382Z [argoexec]       --client-certificate string      Path to a client certificate file for TLS
2025-02-05T09:45:43.382Z [argoexec]       --client-key string              Path to a client key file for TLS
2025-02-05T09:45:43.382Z [argoexec]       --cluster string                 The name of the kubeconfig cluster to use
2025-02-05T09:45:43.382Z [argoexec]       --context string                 The name of the kubeconfig context to use
2025-02-05T09:45:43.382Z [argoexec]       --gloglevel int                  Set the glog logging level
2025-02-05T09:45:43.382Z [argoexec]   -h, --help                           help for argoexec
2025-02-05T09:45:43.382Z [argoexec]       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
2025-02-05T09:45:43.382Z [argoexec]       --kubeconfig string              Path to a kube config. Only required if out-of-cluster
2025-02-05T09:45:43.382Z [argoexec]       --log-format string              The formatter to use for logs. One of: text|json (default "text")
2025-02-05T09:45:43.382Z [argoexec]       --loglevel string                Set the logging level. One of: debug|info|warn|error (default "info")
2025-02-05T09:45:43.382Z [argoexec]   -n, --namespace string               If present, the namespace scope for this CLI request
2025-02-05T09:45:43.382Z [argoexec]       --password string                Password for basic authentication to the API server
2025-02-05T09:45:43.382Z [argoexec]       --proxy-url string               If provided, this URL will be used to connect via proxy
2025-02-05T09:45:43.382Z [argoexec]       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
2025-02-05T09:45:43.382Z [argoexec]       --server string                  The address and port of the Kubernetes API server
2025-02-05T09:45:43.382Z [argoexec]       --tls-server-name string         If provided, this name will be used to validate server certificate. If this is not provided, hostname used to contact the server is used.
2025-02-05T09:45:43.382Z [argoexec]       --token string                   Bearer token for authentication to the API server
2025-02-05T09:45:43.382Z [argoexec]       --user string                    The name of the kubeconfig user to use
2025-02-05T09:45:43.382Z [argoexec]       --username string                Username for basic authentication to the API server
2025-02-05T09:45:43.382Z [argoexec] 
2025-02-05T09:45:43.382Z [argoexec] Use "argoexec [command] --help" for more information about a command.
````
