### PR TITLE
feat: `argoexec` create rocks-automation-ci.yaml

### DIFF
--- a/argoexec/rock-ci-metadata.yaml
+++ b/argoexec/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/argo-operators.git
+    replace-image:
+      - file: charms/argo-controller/config.yaml
+        path: options.executor-image.default
+


### PR DESCRIPTION
Closes: https://github.com/canonical/argo-workflows-rocks/issues/42

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.